### PR TITLE
tiny fix in webgpu-fundamentals.md

### DIFF
--- a/webgpu/lessons/webgpu-fundamentals.md
+++ b/webgpu/lessons/webgpu-fundamentals.md
@@ -570,7 +570,7 @@ We start off with the same code to get a WebGPU device.
 
 ```js
 async function main() {
-  const adapter = await gpu?.requestAdapter();
+  const adapter = await navigator.gpu?.requestAdapter();
   const device = await adapter?.requestDevice();
   if (!device) {
     fail('need a browser that supports WebGPU');


### PR DESCRIPTION
The example code should contain `navigator.gpu` instead of `gpu`, otherwise it won't work. The other code snippets do it correctly.