### PR TITLE
Consistently use vec3u return type for computeSomething in fundamentals

### DIFF
--- a/webgpu/lessons/ja/webgpu-fundamentals.md
+++ b/webgpu/lessons/ja/webgpu-fundamentals.md
@@ -523,7 +523,7 @@ async function main() {
       @group(0) @binding(0) var<storage, read_write> data: array<f32>;
 
       @compute @workgroup_size(1) fn computeSomething(
-        @builtin(global_invocation_id) id: vec3<u32>
+        @builtin(global_invocation_id) id: vec3u
       ) {
         let i = id.x;
         data[i] = data[i] * 2.0;

--- a/webgpu/lessons/ko/webgpu-fundamentals.md
+++ b/webgpu/lessons/ko/webgpu-fundamentals.md
@@ -508,7 +508,7 @@ async function main() {
       @group(0) @binding(0) var<storage, read_write> data: array<f32>;
 
       @compute @workgroup_size(1) fn computeSomething(
-        @builtin(global_invocation_id) id: vec3<u32>
+        @builtin(global_invocation_id) id: vec3u
       ) {
         let i = id.x;
         data[i] = data[i] * 2.0;

--- a/webgpu/lessons/uk/webgpu-fundamentals.md
+++ b/webgpu/lessons/uk/webgpu-fundamentals.md
@@ -595,7 +595,7 @@ async function main() {
       @group(0) @binding(0) var<storage, read_write> data: array<f32>;
 
       @compute @workgroup_size(1) fn computeSomething(
-        @builtin(global_invocation_id) id: vec3<u32>
+        @builtin(global_invocation_id) id: vec3u
       ) {
         let i = id.x;
         data[i] = data[i] * 2.0;

--- a/webgpu/lessons/webgpu-fundamentals.md
+++ b/webgpu/lessons/webgpu-fundamentals.md
@@ -587,7 +587,7 @@ Then we create a shader module.
       @group(0) @binding(0) var<storage, read_write> data: array<f32>;
 
       @compute @workgroup_size(1) fn computeSomething(
-        @builtin(global_invocation_id) id: vec3<u32>
+        @builtin(global_invocation_id) id: vec3u
       ) {
         let i = id.x;
         data[i] = data[i] * 2.0;

--- a/webgpu/lessons/zh_cn/webgpu-fundamentals.md
+++ b/webgpu/lessons/zh_cn/webgpu-fundamentals.md
@@ -430,7 +430,7 @@ const module = device.createShaderModule({
       @group(0) @binding(0) var<storage, read_write> data: array<f32>;
 
       @compute @workgroup_size(1) fn computeSomething(
-        @builtin(global_invocation_id) id: vec3<u32>
+        @builtin(global_invocation_id) id: vec3u
       ) {
         let i = id.x;
         data[i] = data[i] * 2.0;


### PR DESCRIPTION
Hey! I just noticed that the examples were using different return types. The full listing used `vec3<u32>`, the explanation and further listings used `vec3u`.