### PR TITLE
bugfix: Vertex should be replaced with a array<vec2f>

### DIFF
--- a/webgpu/lessons/webgpu-storage-buffers.md
+++ b/webgpu/lessons/webgpu-storage-buffers.md
@@ -35,8 +35,10 @@ appropriate names.
 and in our WSGL
 
 ```wsgl
-      @group(0) @binding(0) var<storage, read> ourStruct: OurStruct;
-      @group(0) @binding(1) var<storage, read> otherStruct: OtherStruct;
+-@group(0) @binding(0) var<uniform> ourStruct: OurStruct;
+-@group(0) @binding(1) var<uniform> otherStruct: OtherStruct;
++@group(0) @binding(0) var<storage, read> ourStruct: OurStruct;
++@group(0) @binding(1) var<storage, read> otherStruct: OtherStruct;
 ```
 
 And with no other changes it works, just like before.
@@ -467,7 +469,11 @@ struct Vertex {
 we could have just as easily used no struct and just directly used a `vec2f`.
 
 ```wgsl
-@group(0) @binding(2) var<storage, read> pos: vec2f;
+-@group(0) @binding(2) var<storage, read> pos: array<Vertex>;
++@group(0) @binding(2) var<storage, read> pos: array<vec2f>;
+...
+-pos[vertexIndex].position * otherStruct.scale + ourStruct.offset, 0.0, 1.0);
++pos[vertexIndex] * otherStruct.scale + ourStruct.offset, 0.0, 1.0);
 ```
 
 But, by making it a struct, it would arguably be easier to add per-vertex

--- a/webgpu/lessons/webgpu-vertex-buffers.md
+++ b/webgpu/lessons/webgpu-vertex-buffers.md
@@ -30,9 +30,10 @@ struct OtherStruct {
   scale: vec2f,
 };
 
-+struct Vertex {
+struct Vertex {
+-  position: vec2f,
 +  @location(0) position: vec2f,
-+};
+};
 
 struct VSOutput {
   @builtin(position) position: vec4f,
@@ -62,8 +63,8 @@ struct VSOutput {
 ...
 ```
 
-As you can see, it's a small change. We declared a struct `Vertex` to define the data
-for a vertex. The important part is declaring the position field with `@location(0)`
+As you can see, it's a small change. The important part is declaring the
+position field with `@location(0)`
 
 Then, when we create the render pipeline, we have to tell WebGPU how to get data
 for `@location(0)`


### PR DESCRIPTION
Two small changed.

### Wrong type on comment

```
@group(0) @binding(2) var<storage, read> pos: array<Vertex>;
```

could be replaced with:

```
@group(0) @binding(2) var<storage, read> pos: array<vec2f>;
```

instead of:

```
@group(0) @binding(2) var<storage, read> pos: vec2f;
```

### Vertex was already define

The storage buffer article finishes with the shader code using the `Vertex` struct, the vertex buffer article started ignoring it. Changed the diff to show only the relevant changes while keeping continuity.