### PR TITLE
 Typo: adaptor -> adapter

### DIFF
--- a/webgpu/lessons/ko/webgpu-textures.md
+++ b/webgpu/lessons/ko/webgpu-textures.md
@@ -1318,7 +1318,7 @@ canvas.height = Math.max(1, Math.min(height, device.limits.maxTextureDimension2D
   이러한 것이 존재하는 이유는 데스크탑 GPU는 일반적으로 32비트 부동소수점 
   텍스처를 필터링이 가능하지만 2023년 현재를 기준으로 대부분의 모바일 
   장치에서는 불가능하기 때문입니다. 
-  여러분의 어댑터(adaptor)가 `float32-filterable`
+  여러분의 어댑터(adapter)가 `float32-filterable`
   [기능(feature)](webgpu-limits-and-features.html)을 지원하고 
   장치를 요청할 때 이를 활성화하였다면 `r32float`, `rg32float`, 
   `rgba32float` 포맷이 `float`으로 변화하고 

--- a/webgpu/lessons/webgpu-fundamentals.md
+++ b/webgpu/lessons/webgpu-fundamentals.md
@@ -236,7 +236,7 @@ Then we need a `<script>` tag to hold our JavaScript.
 All of the JavaScript below will go inside this script tag
 
 WebGPU is an asynchronous API so it's easiest to use in an async function. We
-start off by requesting an adaptor, and then requesting a device from the adapter.
+start off by requesting an adapter, and then requesting a device from the adapter.
 
 ```js
 async function main() {

--- a/webgpu/lessons/webgpu-textures.md
+++ b/webgpu/lessons/webgpu-textures.md
@@ -1351,7 +1351,7 @@ For example "rg11b10ufloat" is "rg11" so 11bits each of red and green. "b10" so
   create a bind group layout, something we haven't done before as we've been
   using `'auto'` layout. This mostly exists because desktop GPU can generally
   filter 32bit floating point textures but, at least as of 2023, most mobile
-  devices can not. If your adaptor supports the `float32-filterable`
+  devices can not. If your adapter supports the `float32-filterable`
   [feature](webgpu-limits-and-features.html) and you enable it when requesting a
   device then the formats `r32float`, `rg32float`, and `rgba32float` switch from
   `unfilterable-float` to `float` and these textures formats will work with no


### PR DESCRIPTION
Fixed a typo I noticed on the first tutorial. For completeness, I replaced all three occurrences, including a Korean translation.