### PR TITLE
MemoryLayout: swap struct/array table header align & size

### DIFF
--- a/webgpu/lessons/uk/webgpu-memory-layout.md
+++ b/webgpu/lessons/uk/webgpu-memory-layout.md
@@ -392,7 +392,7 @@ struct Ex4 {
   </style>
   <table class="wgsl-types">
     <thead>
-      <tr><th>type</th><th>size</th><th>align</th><tr>
+      <tr><th>type</th><th>align</th><th>size</th><tr>
     </thead>
     <tbody>
       <tr><td><code>struct</code> S with members M<sub>1</sub>...M<sub>N</sub></td><td>max(AlignOfMember(S,1), ... , AlignOfMember(S,N))</td><td>roundUp(AlignOf(S), justPastLastMember)

--- a/webgpu/lessons/webgpu-memory-layout.md
+++ b/webgpu/lessons/webgpu-memory-layout.md
@@ -376,7 +376,7 @@ even though the array is a single `vec3f` and the `Ex4a` struct is also a single
   </style>
   <table class="wgsl-types">
     <thead>
-      <tr><th>type</th><th>size</th><th>align</th><tr>
+      <tr><th>type</th><th>align</th><th>size</th><tr>
     </thead>
     <tbody>
       <tr><td><code>struct</code> S with members M<sub>1</sub>...M<sub>N</sub></td><td>max(AlignOfMember(S,1), ... , AlignOfMember(S,N))</td><td>roundUp(AlignOf(S), justPastLastMember)


### PR DESCRIPTION
Small fix on "WebGPU Data Memory-Layout" page.

On the section that explains how `Struct` and `Array` have unique rules for Alignment & Size, the table which is a reflection of [WGSL spec](https://www.w3.org/TR/WGSL/#alignment-and-size), have the header names swapped.

I've believe only the ukranian translation also contains the same table, which have also been updated. Others don't appear to, but if I missed any, please let me know and I'll patch the PR.