### PR TITLE
Fixed typos "2st triangle" and added missing comments for "1st triangle" where appropriate.

### DIFF
--- a/webgpu/lessons/webgpu-compute-shaders-histogram-part-2.md
+++ b/webgpu/lessons/webgpu-compute-shaders-histogram-part-2.md
@@ -527,12 +527,12 @@ and create pipelines for each one.
         @builtin(vertex_index) vertexIndex : u32
       ) -> OurVertexShaderOutput {
         let pos = array(
-
+          // 1st triangle
           vec2f( 0.0,  0.0),  // center
           vec2f( 1.0,  0.0),  // right, center
           vec2f( 0.0,  1.0),  // center, top
 
-          // 2st triangle
+          // 2nd triangle
           vec2f( 0.0,  1.0),  // center, top
           vec2f( 1.0,  0.0),  // right, center
           vec2f( 1.0,  1.0),  // right, top

--- a/webgpu/lessons/webgpu-cube-maps.md
+++ b/webgpu/lessons/webgpu-cube-maps.md
@@ -299,12 +299,12 @@ Now we need to update `generateMips` to handle multiple sources.
               @builtin(vertex_index) vertexIndex : u32
             ) -> VSOutput {
               let pos = array(
-
+                // 1st triangle
                 vec2f( 0.0,  0.0),  // center
                 vec2f( 1.0,  0.0),  // right, center
                 vec2f( 0.0,  1.0),  // center, top
 
-                // 2st triangle
+                // 2nd triangle
                 vec2f( 0.0,  1.0),  // center, top
                 vec2f( 1.0,  0.0),  // right, center
                 vec2f( 1.0,  1.0),  // right, top

--- a/webgpu/lessons/webgpu-importing-textures.md
+++ b/webgpu/lessons/webgpu-importing-textures.md
@@ -190,12 +190,12 @@ Here's the code
               @builtin(vertex_index) vertexIndex : u32
             ) -> VSOutput {
               let pos = array(
-
+                // 1st triangle
                 vec2f( 0.0,  0.0),  // center
                 vec2f( 1.0,  0.0),  // right, center
                 vec2f( 0.0,  1.0),  // center, top
 
-                // 2st triangle
+                // 2nd triangle
                 vec2f( 0.0,  1.0),  // center, top
                 vec2f( 1.0,  0.0),  // right, center
                 vec2f( 1.0,  1.0),  // right, top

--- a/webgpu/lessons/webgpu-textures-external-video.md
+++ b/webgpu/lessons/webgpu-textures-external-video.md
@@ -100,12 +100,12 @@ struct Uniforms {
   @builtin(vertex_index) vertexIndex : u32
 ) -> OurVertexShaderOutput {
   let pos = array(
-
+    // 1st triangle
     vec2f( 0.0,  0.0),  // center
     vec2f( 1.0,  0.0),  // right, center
     vec2f( 0.0,  1.0),  // center, top
 
-    // 2st triangle
+    // 2nd triangle
     vec2f( 0.0,  1.0),  // center, top
     vec2f( 1.0,  0.0),  // right, center
     vec2f( 1.0,  1.0),  // right, top

--- a/webgpu/lessons/webgpu-textures.md
+++ b/webgpu/lessons/webgpu-textures.md
@@ -89,7 +89,7 @@ struct OurVertexShaderOutput {
 +    vec2f( 1.0,  0.0),  // right, center
 +    vec2f( 0.0,  1.0),  // center, top
 +
-+    // 2st triangle
++    // 2nd triangle
 +    vec2f( 0.0,  1.0),  // center, top
 +    vec2f( 1.0,  0.0),  // right, center
 +    vec2f( 1.0,  1.0),  // right, top
@@ -501,7 +501,7 @@ struct OurVertexShaderOutput {
     vec2f( 1.0,  0.0),  // right, center
     vec2f( 0.0,  1.0),  // center, top
 
-    // 2st triangle
+    // 2nd triangle
     vec2f( 0.0,  1.0),  // center, top
     vec2f( 1.0,  0.0),  // right, center
     vec2f( 1.0,  1.0),  // right, top
@@ -991,12 +991,12 @@ struct Uniforms {
   @builtin(vertex_index) vertexIndex : u32
 ) -> OurVertexShaderOutput {
   let pos = array(
-
+    // 1st triangle
     vec2f( 0.0,  0.0),  // center
     vec2f( 1.0,  0.0),  // right, center
     vec2f( 0.0,  1.0),  // center, top
 
-    // 2st triangle
+    // 2nd triangle
     vec2f( 0.0,  1.0),  // center, top
     vec2f( 1.0,  0.0),  // right, center
     vec2f( 1.0,  1.0),  // right, top

--- a/webgpu/lessons/webgpu-transparency.md
+++ b/webgpu/lessons/webgpu-transparency.md
@@ -566,12 +566,12 @@ draw a long plane into the distance.
   @builtin(vertex_index) vertexIndex : u32
 ) -> OurVertexShaderOutput {
   let pos = array(
-
+    // 1st triangle
     vec2f( 0.0,  0.0),  // center
     vec2f( 1.0,  0.0),  // right, center
     vec2f( 0.0,  1.0),  // center, top
 
-    // 2st triangle
+    // 2nd triangle
     vec2f( 0.0,  1.0),  // center, top
     vec2f( 1.0,  0.0),  // right, center
     vec2f( 1.0,  1.0),  // right, top


### PR DESCRIPTION
Various instances of "2st triangle" corrected to "2nd triangle" in vertex shader comments.

Various instances where "1st triangle" is missing in vertex shader comments where "2nd triangle" is present alone.