### PR TITLE
Remove comment on how to format code in comments

### DIFF
--- a/webgpu/lessons/ko/langinfo.hanson
+++ b/webgpu/lessons/ko/langinfo.hanson
@@ -13,9 +13,6 @@
    <a href="https://github.com/webgpu/webgpufundamentals/issues/new?assignees=&labels=bug+%2F+issue&template=bug-issue-report.md&title=">이슈</a> /
    <a href="https://github.com/webgpu/webgpufundamentals/issues/new?assignees=&labels=bug+%2F+issue&template=bug-issue-report.md&title=">버그</a>
 </div>
-<div class="lesson-comment-notes">
-   코드 블럭의 경우 <b>&lt;pre&gt;&lt;code&gt;</b>코드<b>&lt;/code&gt;&lt;/pre&gt;</b>을 사용하세요.
-</div>
   `,
   missing: `
 죄송합니다. 이 글은 아직 번역이 되지 않았습니다.

--- a/webgpu/lessons/langinfo.hanson
+++ b/webgpu/lessons/langinfo.hanson
@@ -13,9 +13,6 @@
    <a href="https://github.com/webgpu/webgpufundamentals/issues/new?assignees=&labels=bug+%2F+issue&template=bug-issue-report.md&title=">Issue</a>?
    <a href="https://github.com/webgpu/webgpufundamentals/issues/new?assignees=&labels=bug+%2F+issue&template=bug-issue-report.md&title=">Bug</a>?
 </div>
-<div class="lesson-comment-notes">
-   Use <b>&lt;pre&gt;&lt;code&gt;</b>code goes here<b>&lt;/code&gt;&lt;/pre&gt;</b> for code blocks
-</div>
   `,
   missing: `
 Sorry this article has not been translated yet.

--- a/webgpu/lessons/uk/langinfo.hanson
+++ b/webgpu/lessons/uk/langinfo.hanson
@@ -13,9 +13,6 @@
    <a href="https://github.com/webgpu/webgpufundamentals/issues/new?assignees=&labels=bug+%2F+issue&template=bug-issue-report.md&title=">Проблема</a>?
    <a href="https://github.com/webgpu/webgpufundamentals/issues/new?assignees=&labels=bug+%2F+issue&template=bug-issue-report.md&title=">Помилка</a>?
 </div>
-<div class="lesson-comment-notes">
-   Use <b>&lt;pre&gt;&lt;code&gt;</b>code goes here<b>&lt;/code&gt;&lt;/pre&gt;</b> for code blocks
-</div>
   `,
   missing: `
 Вибачте, ця стаття ще не була перекладена.

--- a/webgpu/lessons/zh_cn/langinfo.hanson
+++ b/webgpu/lessons/zh_cn/langinfo.hanson
@@ -8,9 +8,6 @@
   commentSectionHeader: `
 <div>有疑问? <a href="https://stackoverflow.com/questions/tagged/webgpu">在stackoverflow上提问</a>.</div>
 <div>Issue/Bug? <a href="https://github.com/webgpu/webgpufundamentals/issues">在GitHub上提issue</a>.</div>
-<div class="lesson-comment-notes">
-   使用 <b>&lt;pre&gt;&lt;code&gt;</b> 代码 <b>&lt;/code&gt;&lt;/pre&gt;</b> 的格式编写代码块
-</div>
   `,
   missing: `
 本课程还没有简体中文版翻译哦  (~￣△￣)~\n\n


### PR DESCRIPTION
Disqus changed their UI. It's unclear how to leave code in comments. They have a toolbar that's hidden by default. Enabling it, it has a code button but
it doesn't seem to work.

They have docs https://help.disqus.com/en/articles/1717235-comment-text-formatting but they don't seem to work?