### PR TITLE
Fixes mat4x4 projection in orthographic projection tutorial (3D Section)

### DIFF
--- a/webgpu/lessons/webgpu-orthographic-projection.md
+++ b/webgpu/lessons/webgpu-orthographic-projection.md
@@ -618,8 +618,8 @@ expanding it to 3D let's try
     dst = dst || new Float32Array(16);
     dst[ 0] = 2 / width;  dst[ 1] = 0;            dst[ 2] = 0;          dst[ 3] = 0;
     dst[ 4] = 0;          dst[ 5] = -2 / height;  dst[ 6] = 0;          dst[ 7] = 0;
-    dst[ 8] = 0;          dst[ 9] = 0;            dst[10] = 2 / depth;  dst[11] = 0;
-    dst[12] = -1;         dst[13] = 1;            dst[14] = 1;          dst[15] = 1;
+    dst[ 8] = 0;          dst[ 9] = 0;            dst[10] = 0.5 / depth;  dst[11] = 0;
+    dst[12] = -1;         dst[13] = 1;            dst[14] = 0.5;          dst[15] = 1;
     return dst;
   },
 ```


### PR DESCRIPTION
It seems there is a misalignment between what the code snippet of the projection matrix shows and whats in the runnable example. Lost a considerable amount of time trying to understand where the issue is until I saw that the depth is divided by by half and 14th element of the projection matrix is 0.5 as instead of 1.0.