### PR TITLE
Clarify that @group(?) is also passed in webgpu-uniforms.md

### DIFF
--- a/webgpu/lessons/webgpu-uniforms.md
+++ b/webgpu/lessons/webgpu-uniforms.md
@@ -143,8 +143,8 @@ to the left 1/4th of the canvas and down 1/8th. (remember, clip space goes
 from -1 to 1 which is 2 units wide so 0.25 is 1/8 of 2). 
 
 Next, [as the diagram showed in the first article](webgpu-fundamentals.html#a-draw-diagram),
-to tell a shader about our buffer we need to create a bind group
-and bind the buffer to the same `@binding(?)` we set in our shader.
+to tell a shader about our buffer we need to create a bind group and bind the buffer.
+We need to pass the same `@group(?)` and `@binding(?)` we set in our shader.
 
 ```js
   const bindGroup = device.createBindGroup({


### PR DESCRIPTION
Took me a second to realize that the `0` in `pipeline.getBindGroupLayout(0)` is the `@group(0)`.

I made a change to clarify this.