### PR TITLE
Clarify minimum maximum in webgpu-storage-buffers.md

### DIFF
--- a/webgpu/lessons/webgpu-storage-buffers.md
+++ b/webgpu/lessons/webgpu-storage-buffers.md
@@ -60,13 +60,11 @@ The major differences between uniform buffers and storage buffers are:
 
 2. Storage buffers can be much larger than uniform buffers.
 
-   * The minimum maximum size of a uniform buffer is 64k 
-   * The minimum maximum size of a storage buffer is 128meg
+   * By default, the maximum size of a uniform buffer is 64 kiB (65536 bytes).
+   * By default, the maximum size of a a storage buffer is 128 MiB (134217728 bytes).
 
-   By minimum maximum, there is a maximum size a buffer of a certain type
-   can be. For uniform buffers, the maximum size is at least 64k.
-   For storage buffers, it's at least 128meg. We'll cover limits in
-   [another article](webgpu-limits-and-features.html).
+   All implementations are required to support at least these sizes. We'll cover limits in
+   detail in [another article](webgpu-limits-and-features.html).
 
 3. Storage buffers can be read/write, Uniform buffers are read-only.
 

--- a/webgpu/lessons/webgpu-storage-buffers.md
+++ b/webgpu/lessons/webgpu-storage-buffers.md
@@ -63,7 +63,7 @@ The major differences between uniform buffers and storage buffers are:
    * By default, the maximum size of a uniform buffer is 64 kiB (65536 bytes).
    * By default, the maximum size of a storage buffer is 128 MiB (134217728 bytes).
 
-   All implementations are required to support at least these sizes. We'll cover limits in
+   All implementations are required to support at least these sizes. We'll cover how to check for and request larger limits in
    detail in [another article](webgpu-limits-and-features.html).
 
 3. Storage buffers can be read/write, Uniform buffers are read-only.

--- a/webgpu/lessons/webgpu-storage-buffers.md
+++ b/webgpu/lessons/webgpu-storage-buffers.md
@@ -61,7 +61,7 @@ The major differences between uniform buffers and storage buffers are:
 2. Storage buffers can be much larger than uniform buffers.
 
    * By default, the maximum size of a uniform buffer is 64 kiB (65536 bytes).
-   * By default, the maximum size of a a storage buffer is 128 MiB (134217728 bytes).
+   * By default, the maximum size of a storage buffer is 128 MiB (134217728 bytes).
 
    All implementations are required to support at least these sizes. We'll cover limits in
    detail in [another article](webgpu-limits-and-features.html).


### PR DESCRIPTION
I have tried to clarify the wording of the limits in `webgpu-storage-buffers.md`.

- Use official units instead of the more informal 'k' and 'meg'.
- Do not use the term 'minimum maximum'. This is confusing since the concept that different implementations can have different maximums is not introduced. Clarify this with a sentence instead.
- Write out the maximums in bytes as well to really drive home the point of the size differences.