### PR TITLE
Fix awkward Korean phrasing and typos in webgpu-multisampling.md (ko)

### DIFF
--- a/webgpu/lessons/ko/webgpu-multisampling.md
+++ b/webgpu/lessons/ko/webgpu-multisampling.md
@@ -9,19 +9,19 @@ MSAA는 멀티샘플링 안티앨리어싱(Multi-Sampling Anti-aliasing)의 약�
 <div class="webgpu_center side-by-side flex-gap" style="max-width: 850px">
   <div class="multisample-example">
     <div data-diagram="clip-space-to-texels"></div>
-    <div>drag the vertices</div>
+    <div>버텍스 끌기</div>
   </div>
   <div class="multisample-example">
     <div data-diagram="clip-space-to-texels-result"></div>
-    <div>result</div>
+    <div>결과</div>
   </div>
 </div>
 
-이 삼각형은 매우 블록처럼 보입니다. 해상도를 높여볼 수 도 있겠지만, 최대로 높일 수 있는 해상도는 디스플레이에 한계까지고 이마자도 충분하지 않을 수 있습니다.
+이 삼각형은 계단 현상이 심하게 나타납니다. 해상도를 높여 볼 수도 있겠지만, 최대 해상도는 디스플레이의 한계에 불과하며, 그마저도 충분하지 않을 수 있습니다.
 
-한 가지 해결법은 더 높은 해상도를 랜더링하는 것입니다. 예를 들어 해상도는 4배(가로 2배, 세로 2배)로 높인 뒤에 "이중 선형 필터(bilinear filer)"룰 이용해 캔버스의 결과를 보여줄 수 있습니다.
-"이중 선형 필터(bilinear filtering)"에 대해서는 
-[the article on textures](webgpu-textures.html)를 참고하세요.
+한 가지 해결법은 더 높은 해상도로 렌더링하는 것입니다. 예를 들어 해상도를 4배(가로 2배, 세로 2배)로 높인 뒤, "이중 선형 필터링(bilinear filtering)을 이용해 캔버스에 결과를 표시할 수 있습니다."
+"이중 선형 필터링(bilinear filtering)"에 대해서는 
+[텍스쳐 설명 글](webgpu-textures.html)을 참고하세요.
 
 <div class="webgpu_center side-by-side flex-gap" style="max-width: 850px">
   <div class="multisample-example">
@@ -30,7 +30,7 @@ MSAA는 멀티샘플링 안티앨리어싱(Multi-Sampling Anti-aliasing)의 약�
   </div>
   <div class="multisample-example">
     <div data-diagram="clip-space-to-texels-4x-result"></div>
-    <div>이중 선형 필터 결과</div>
+    <div>이중 선형 필터링 결과</div>
   </div>
 </div>
 
@@ -39,7 +39,7 @@ MSAA는 멀티샘플링 안티앨리어싱(Multi-Sampling Anti-aliasing)의 약�
 <div class="webgpu_center side-by-side flex-gap">
   <div class="multisample-example">
     <div data-diagram="clip-space-to-texels-4x-waste"></div>
-    <div>3 of every 4 <span style="color: cyan;">cyan</span> pixels are wasted</div>
+    <div>4개중 3개의<span style="color: cyan;">청록색</span>픽셀들이 낭비됩니다.</div>
   </div>
 </div>
 
@@ -49,7 +49,7 @@ MSAA는 멀티샘플링 안티앨리어싱(Multi-Sampling Anti-aliasing)의 약�
   <img src="resources/antialias-4x.svg" width="600">
 </div>
 
-위 예시에서는 4배 렌더링(4x rendering)을 사용할 때, 삼각형이 3개 픽셀의 중심을 덮으면 프래그먼트 셰이더가 3번 호출됩니다. 이후 결과에 이중 선형 필터링(bilinear filtering)을 적용하게 됩니다.
+위 예시에서는 4배 렌더링(4x rendering)을 사용할 때, 삼각형이 3개 픽셀의 중심을 덮으면 프래그먼트 셰이더가 3번 호출됩니다. 이후 결과에 이중선형 필터링(bilinear filtering)을 적용하게 됩니다.
 
 바로 이 부분에서 멀티샘플링(multisampling)의 효율성이 더 뛰어납니다. 멀티샘플링을 사용하면 특수한 '멀티샘플 텍스처(multisample texture)'를 생성합니다. 이 멀티샘플 텍스처에 삼각형을 그릴 때, 4개의 '샘플(samples)' 중 하나라도 삼각형 내부에 있으면 GPU는 프래그먼트 셰이더를 단 한 번 호출합니다. 그 후 삼각형 내부에 위치한 샘플에만 결과를 기록하게 됩니다.
 
@@ -57,21 +57,21 @@ MSAA는 멀티샘플링 안티앨리어싱(Multi-Sampling Anti-aliasing)의 약�
   <img src="resources/antialias-multisample-4.svg" width="600">
 </div>
 
-위의 예시에서 멀티샘플링 렌더링을 사용할 경우, 삼각형이 3개의 *샘플(samples)*을 덮더라도 프래그먼트 셰이더는 단 한 번만 호출됩니다. 그런 다음, 이 결과를 하나의 픽셀로 병합하는 *리졸브(resolve)* 과정을 거칩니다. 삼각형이 만약 4개의 샘플 모두를 덮는 경우에도 과정은 비슷합니다. 프래그먼트 셰이더는 한 번만 호출되며, 그 결과는 4개의 샘플 모두에 기록됩니다.
+위의 예시에서 멀티샘플링 렌더링을 사용할 경우, 삼각형이 3개의 *샘플(samples)*을 덮더라도 프래그먼트 셰이더는 단 한 번만 호출됩니다. 그런 다음, 이 결과를 하나의 픽셀로 병합하는 *병합(resolve)* 과정을 거칩니다. 삼각형이 만약 4개의 샘플 모두를 덮는 경우에도 과정은 비슷합니다. 프래그먼트 셰이더는 한 번만 호출되며, 그 결과는 4개의 샘플 모두에 기록됩니다.
 
-여기서 주목할 점은, 기존의 4x 렌더링 방식에서는 CPU가 픽셀 4개의 중심이 삼각형 안에 있는지 확인한 반면, 멀티샘플링(multisampled) 렌더링에서는 GPU가 격자(grid)에 정렬되지 않은 '샘플 위치(sample positions)'를 검사한다는 점입니다. 비슷하게 샘플 값(sample values) 또한 정형화된 격자를 이루지 않기 때문에, 이 값들을 하나의 픽셀로 "병합(resolving)" 하는 과정 역시 이중 선형 필터링(bilinear filtering)이 아니라 GPU에 의해 처리됩니다. 이렇게 픽셀 중심에서 벗어난 비정형 샘플 위치는 대부분의 상황에서 더 나은 안티 앨리어싱 효과를 제공하게 됩니다.
+여기서 주목할 점은, 기존의 4배 렌더링 방식에서는 CPU가 픽셀 4개의 중심이 삼각형 안에 있는지 확인한 반면, 멀티샘플링(multisampled) 렌더링에서는 GPU가 격자(grid)에 정렬되지 않은 '샘플 위치(sample positions)'를 검사한다는 점입니다. 비슷하게 샘플 값(sample values) 또한 정형화된 격자를 이루지 않기 때문에, 이 값들을 하나의 픽셀로 "병합(resolving)" 하는 과정 역시 이중선형 필터링(bilinear filtering)이 아니라 GPU에 의해 처리됩니다. 이렇게 픽셀 중심에서 벗어난 비정형 샘플 위치는 대부분의 상황에서 더 나은 안티 앨리어싱 효과를 제공하게 됩니다.
 
-## <a id="a-multisampling"></a> How to use multisampling.
+## <a id="a-multisampling"></a> 멀티샘플링 사용 방법
 
 그래서 어떻게 멀티샘플링을 할 수 있을까요? 3개 단계를 따르면 됩니다.
 
-1. 파이프라인에서 멀티 샘플 텍스쳐를 랜더링하게 설정하세요.
-2. 멀티 샘플 텍스쳐를 최종 텍스쳐와 같은 크기로 만드세요.
-3. 렌더 패스(render pass)를 설정할 때, 멀티샘플 텍스처로 렌더링한 후 그 결과를 최종 텍스처(canvas)에 병합합(resolve) 하도록 합니다.
+1. 파이프라인에서 멀티 샘플 텍스처로 렌더링하도록 설정하세요.
+2. 멀티 샘플 텍스처를 최종 텍스처와 같은 크기로 만드세요.
+3. 렌더 패스(render pass)를 설정할 때, 멀티샘플 텍스처로 렌더링한 후 그 결과를 최종 텍스처(canvas)에 병합(resolve)하도록 합니다.
 
 간단히 하기 위해, [기본 개념 문서](webgpu-fundamentals.html#a-resizing) 끝부분에 있는 반응형(responsive) 삼각형 예제를 가져와서, 여기에 멀티샘플링(multisampling)을 추가해 봅시다.
 
-### 파이프라인에서 멀티 샘플 텍스쳐를 랜더링하게 설정하세요.
+### 파이프라인에서 멀티 샘플 텍스처로 렌더링하도록 설정하세요.
 
 ```js
   const pipeline = device.createRenderPipeline({
@@ -92,13 +92,13 @@ MSAA는 멀티샘플링 안티앨리어싱(Multi-Sampling Anti-aliasing)의 약�
 
 위에 `multisample` 설정을 추가하면, 이 파이프라인은 멀티샘플 텍스처로 렌더링할 수 있게 됩니다.
 
-### 멀티 샘플 텍스쳐를 최종 텍스쳐와 같은 크기로 만드세요.
+### 멀티 샘플 텍스처를 최종 텍스처와 같은 크기로 만드세요.
 
 최종 텍스처는 캔버스(canvas)의 텍스처입니다. 사용자가 창 크기를 조절하는 등의 이유로 캔버스 크기가 바뀔 수 있으므로, 이 텍스처는 렌더링할 때마다 생성해주어야 합니다.
 
 
 ```js
-+  let multisampleTexture;
+  let multisampleTexture;
 
   function render() {
 +    // Get the current texture from the canvas context
@@ -136,28 +136,28 @@ MSAA는 멀티샘플링 안티앨리어싱(Multi-Sampling Anti-aliasing)의 약�
 
 
 
-### 렌더 패스(render pass)를 설정할 때, 멀티샘플 텍스처로 렌더링한 후 그 결과를 최종 텍스처(canvas)에 병합(resolve) 하도록 합니다.
+### 렌더 패스(render pass)를 설정할 때, 멀티샘플 텍스처로 렌더링한 후 그 결과를 최종 텍스처(canvas)에 병합(resolve)하도록 합니다.
 
 ```js
--    // Get the current texture from the canvas context and
--    // set it as the texture to render to.
+-    // 캔버스 컨텍스트에서 현재 텍스처를 가져와서
+-    // 렌더링할 텍스처로 설정합니다.
 -    renderPassDescriptor.colorAttachments[0].view =
 -        context.getCurrentTexture().createView();
 
-+    // Set the multisample texture as the texture to render to
++    // 멀티샘플 텍스처를 렌더링할 텍스처로 설정합니다
 +    renderPassDescriptor.colorAttachments[0].view =
 +        multisampleTexture.createView();
-+    // Set the canvas texture as the texture to "resolve"
-+    // the multisample texture to.
++    // 캔버스 텍스처를 멀티샘플 텍스처를 "병합"할
++    // 대상 텍스처로 설정합니다.
 +    renderPassDescriptor.colorAttachments[0].resolveTarget =
 +        canvasTexture.createView();
 ```
 
 *병합(resolve)*이란 멀티샘플 텍스처의 데이터를 우리가 실제로 원하는 크기의 텍스처로 변환하는 과정입니다. 이 예제에서는 그 대상이 바로 캔버스입니다.
 
-앞서 4배(4x) 렌더링 예제에서는 4배 크기의 텍스처를 생성한 후, 그것을 1배 크기의 텍스처로 양선형 필터링(bilinear filtering)을 통해 직접접 축소(resize)했었습니다.
+앞서 4배(4x) 렌더링 예제에서는 4배 크기의 텍스처를 생성한 후, 그것을 1배 크기의 텍스처로 이중선형 필터링(bilinear filtering)을 통해 직접접 축소(resize)했었습니다.
 
-멀티샘플링에서도 이와 유사한 방식으로 처리되긴 하지만, 멀티샘플 텍스처는 실제로는 양선형 필터링을 사용하지 않습니다.
+멀티샘플링에서도 이와 유사한 방식으로 처리되긴 하지만, 멀티샘플 텍스처는 실제로는 이중선형 필터링을 사용하지 않습니다.
 
 자세한 내용은 아래의  [격자가 아닌 구조](#a-not-a-grid)를 참고하세요.
 
@@ -173,17 +173,17 @@ MSAA는 멀티샘플링 안티앨리어싱(Multi-Sampling Anti-aliasing)의 약�
 <div class="webgpu_center side-by-side flex-gap" style="max-width: 850px">
   <div class="multisample-example">
     <div data-diagram="simple-triangle"></div>
-    <div>original</div>
+    <div>원본</div>
   </div>
   <div class="multisample-example">
     <div data-diagram="simple-triangle-multisample"></div>
-    <div>with multisampling</div>
+    <div>멀티샘플링이 적용된 버전</div>
   </div>
 </div>
 
 다음을 기억하세요.
 
-## `count`는 꼭 `4` 여야 합니다.
+## `count`는 반드시 `4`여야 합니다.
 
 WebGPU 버전 1에서는 렌더 파이프라인의 `multisample: { count }` 설정 값으로 1 또는 4만 사용할 수 있습니다.
 마찬가지로 텍스처를 생성할 때 설정하는 `sampleCount` 역시 1 또는 4만 허용됩니다.
@@ -191,7 +191,7 @@ WebGPU 버전 1에서는 렌더 파이프라인의 `multisample: { count }` 설�
 1은 기본값이며, 텍스처가 멀티샘플링되지 않은(non-multisampled) 상태임을 의미합니다.
 4를 설정하면 4x 멀티샘플링이 적용되어 안티 앨리어싱 품질이 향상됩니다.
 
-## <a id="a-not-a-grid"></a> Multisampling does not use a grid
+## <a id="a-not-a-grid"></a> 멀티샘플링은 격자(grid)를 사용하지 않습니다
 
 앞서 언급했듯이, 멀티샘플링은 일반적인 격자(grid) 형태로 이루어지지 않습니다.
 sampleCount = 4일 때, 샘플 위치는 다음과 같은 방식으로 배치됩니다:
@@ -218,9 +218,9 @@ sampleCount = 4일 때, 샘플 위치는 다음과 같은 방식으로 배치됩
 
 **WebGPU 는 현재 count 4만 지원합니다.**
 
-## 모든 렌더 패스에서 resolve target을 설정할 필요는 없습니다.
+## 모든 렌더 패스에서 `resolveTarget`을 설정할 필요는 없습니다.
 
-`colorAttachment[0].resolveTarget`을 설정하면 WebGPU에게 “이 렌더 패스의 모든 그리기가 완료되면, 멀티샘플 텍스처를 `resolveTarget`에 설정된 텍스처로 다운스케일하라”고 지시하는 것입니다. 여러 개의 렌더 패스가 있는 경우, 마지막 패스까지 resolve하지 않는 것이 좋습니다. 마지막 패스에서 resolve하는 것이 가장 빠르지만, resolve만을 위한 빈 마지막 렌더 패스를 만드는 것도 완전히 허용됩니다.
+`colorAttachment[0].resolveTarget`을 설정하면 WebGPU에게 다음과 같이 지시하는 것입니다. "이 렌더 패스의 모든 그리기가 완료되면, 멀티샘플 텍스처를 `resolveTarget`에 설정된 텍스처로 다운스케일하라" 여러 개의 렌더 패스가 있는 경우, 마지막 패스까지 resolve하지 않는 것이 좋습니다. 마지막 패스에서 resolve하는 것이 가장 빠르지만, resolve만을 위한 빈 마지막 렌더 패스를 만드는 것도 완전히 허용됩니다.
 단, 첫 번째 패스를 제외한 모든 패스에서 `loadOp`를 `'clear'`가 아닌 `'load'`로 설정해야 합니다. 그렇지 않으면 텍스처가 지워질 것입니다.
 
 ## 선택적으로 각 샘플 포인트에서 프래그먼트 셰이더를 실행할 수 있습니다.
@@ -230,7 +230,7 @@ sampleCount = 4일 때, 샘플 위치는 다음과 같은 방식으로 배치됩
 [WebGPU에서 인터스테이지 변수에 관한 글](webgpu-inter-stage-variables.html#a-interpolate)에서 우리는 `@interpolate(...)` 속성을 사용하여 인터스테이지 변수의 보간 방법을 지정할 수 있다고 언급했습니다. 여러 옵션 중 하나인 `sample`을 사용하면 프래그먼트 셰이더가 각 샘플마다 한 번씩 실행됩니다.
 WebGPU에는 몇 가지 유용한 내장 변수들이 있습니다. `@builtin(sample_index)`는 현재 작업 중인 샘플이 어떤 것인지 알려주며, `@builtin(sample_mask)`는 입력으로 사용될 때 삼각형 내부에 있는 어떤 샘플들이 있는지 알려주고, 출력으로 사용될 때는 샘플 포인트가 업데이트되는 것을 방지할 수 있게 해줍니다.
 
-## `center` vs `centroid`
+## `center` 대 `centroid`
 
 3가지 *샘플링* 보간 모드가 있습니다. 위에서 우리는 각 샘플마다 프래그먼트 셰이더가 한 번씩 호출되는 `'sample'` 모드에 대해 언급했습니다. 다른 두 가지 모드는 기본값인 `'center'`와 `'centroid'`입니다.
 
@@ -312,13 +312,13 @@ and some CSS
 canvas {
 +  image-rendering: pixelated;
 +  image-rendering: crisp-edges;
-  display: block;  /* make the canvas act like a block   */
-  width: 100%;     /* make the canvas fill its container */
+  display: block;  /* canvas block 설정   */
+  width: 100%;     /* 캔버스가 화면에 꽉차게 설정 */
   height: 100%;
 }
 ```
 
-결과는 다음과 같습니다ㅣ.
+결과는 다음과 같습니다.
 
 {{{example url="../webgpu-multisample-center-issue.html"}}}
 
@@ -345,7 +345,7 @@ struct VOut {
 
 {{{example url="../webgpu-multisample-centroid.html"}}}
 
-> 참고: GPU가 실제로 픽셀 내 삼각형 영역의 중심점을 계산하는지는 확실하지 않습니다. 보장되는 것은 단계 간 변수들이 픽셀과 교차하는 삼각형 부분 내의 어떤 영역을 기준으로 보간된다는 점뿐입니다.
+> 참고: GPU가 실제로 픽셀 내 삼각형 영역의 중심점을 계산하는지는 확실하지 않습니다. 보장되는 것은 인터스테이지 변수들이 픽셀과 교차하는 삼각형 영역 내의 어떤 위치를 기준으로 보간된다는 점뿐입니다.
 
 ## 삼각형 내부의 안티앨리어싱은 어떻게 될까요?
 


### PR DESCRIPTION
This pull request improves the Korean translation of `webgpu/lessons/ko/webgpu-multisampling.md` by fixing awkward expressions, correcting typos, and ensuring consistency in technical terminology.

**Summary of changes:**
- Fixed awkward or unnatural Korean phrasing for better readability and clarity.
- Improved consistency of technical terms (e.g., multisample texture, resolve, bilinear filtering).
- Enhanced code comments and step instructions for clarity.
- Minor formatting and punctuation improvements.

These changes help ensure the documentation is more accurate, professional, and easier to understand for Korean readers.