### PR TITLE
fix incorrect diff deletion line in split uniforms example

### DIFF
--- a/webgpu/lessons/webgpu-uniforms.md
+++ b/webgpu/lessons/webgpu-uniforms.md
@@ -467,8 +467,7 @@ When we need 2 uniform buffers per thing we want to draw
       uniformValues.set([rand(), rand(), rand(), 1], kColorOffset);        // set the color
       uniformValues.set([rand(-0.9, 0.9), rand(-0.9, 0.9)], kOffsetOffset);      // set the offset
 
-      // copy these values to the GPU
--      device.queue.writeBuffer(uniformBuffer, 0, uniformValues);
++     // copy these values to the GPU
 +      device.queue.writeBuffer(staticUniformBuffer, 0, uniformValues);
     }
 


### PR DESCRIPTION
The diff between the first 100-triangles example and the second 100-triangles example incorrectly shows a `writeBuffer` call being deleted in the loop outside `render`. I found this confusing because it seems to imply that everything was already being updated outside of the draw call in the first example (so why does anything need to be updated in `render`?). In actuality, in the first example, `writeBuffer` updates only occur in `render`.