### PR TITLE
fix spelling error in webgpu-debugging.md

### DIFF
--- a/webgpu/lessons/webgpu-debugging.md
+++ b/webgpu/lessons/webgpu-debugging.md
@@ -223,7 +223,7 @@ asynchronously.
 ## WGSL errors
 
 If you get an error compiling a shader module you can ask for more
-detailed info by calling `getComplicationInfo`. 
+detailed info by calling `getCompilationInfo`. 
 
 Example:
 


### PR DESCRIPTION
`getComplicationInfo` -> `getCompilationInfo`