### PR TITLE
Replace deprecated .path property with .parentPath

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -196,10 +196,10 @@ module.exports = function(grunt) {
   grunt.registerTask('buildindex', function() {
     let dirs = fs.readdirSync('out', { withFileTypes: true, recursive: true });
     dirs = dirs.filter(dir => dir.isDirectory());
-    dirs = dirs.filter(dir => !fs.existsSync(path.join(dir.path, dir.name, 'index.html')));
-    dirs = dirs.filter(dir => !(/monaco-editor|types/.test(path.join(dir.path, dir.name))));
+    dirs = dirs.filter(dir => !fs.existsSync(path.join(dir.parentPath, dir.name, 'index.html')));
+    dirs = dirs.filter(dir => !(/monaco-editor|types/.test(path.join(dir.parentPath, dir.name))));
     dirs.forEach(dir => {
-      generateIndex(path.join(dir.path, dir.name));
+      generateIndex(path.join(dir.parentPath, dir.name));
     });
   });
 


### PR DESCRIPTION
I kept getting a `Warning: The "path" argument must be of type string. Received undefined Use --force to continue.` error and was really confused.

Turns out that the `.path` property has been replaced by the `.parentPath` property in newer Node.js versions. This migrates it.