### PR TITLE
Fix unreadable text message box

### DIFF
--- a/webgpu/webgpu-simple-textured-quad-mipmapfilter.html
+++ b/webgpu/webgpu-simple-textured-quad-mipmapfilter.html
@@ -21,7 +21,7 @@ canvas {
   left: 0;
   font-size: 3vh;
   padding: 0.5em;
-  background-color: black;
+  background-color: orange;
   pointer-events: none;
   user-select: none;
 }


### PR DESCRIPTION
In "WebGPU Textures" lesson, we have a unreadable message box.
https://webgpufundamentals.org/webgpu/webgpu-simple-textured-quad-mipmapfilter.html

## Changes
- BG color to orange from black.

| as-is          | to-be          |
|-----------|------------|
| <img width="300" height="250" alt="old-img" src="https://github.com/user-attachments/assets/b68128ee-2640-43bc-9dc7-e4bcd89476ff" /> | <img width="300" height="250" alt="new-img" src="https://github.com/user-attachments/assets/3eefc4e0-79e8-4b14-b811-4b8793a124fd" /> |