### PR TITLE
Add script to scrape local npm run serve and dump to pdf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 node_modules
 out
 extra
+WebGPU_Fundamentals_Full.pdf
 

--- a/make-pdfs.mjs
+++ b/make-pdfs.mjs
@@ -1,0 +1,54 @@
+import puppeteer from 'puppeteer';
+import { PDFDocument } from 'pdf-lib';
+import fs from 'fs';
+
+const BASE_URL = 'http://localhost:8080'; // Your local 'servez' URL
+
+async function generateTutorialPdf() {
+  const browser = await puppeteer.launch({ headless: "new" });
+  const page = await browser.newPage();
+
+  console.log('Finding lesson links...');
+  await page.goto(BASE_URL);
+
+  // Scrape all links that look like lessons
+  const lessonLinks = await page.evaluate(() => {
+    const anchors = Array.from(document.querySelectorAll('a[href*="/lessons/"]'));
+    return anchors
+      .map(a => a.href)
+      .filter(href => href.endsWith('.html'));
+  });
+
+  // Remove duplicates
+  const uniqueLinks = [...new Set(lessonLinks)];
+  console.log(`Found ${uniqueLinks.length} lessons. Starting conversion...`);
+
+  const mergedPdf = await PDFDocument.create();
+
+  for (const link of uniqueLinks) {
+    console.log(`Processing: ${link}`);
+    await page.goto(link, { waitUntil: 'networkidle0' });
+    
+    // Optional: Hide the navbar/UI elements for a cleaner PDF
+    await page.addStyleTag({ content: '.webgpu_navbar, #forkongithub { display: none !important; }' });
+
+    const pdfBytes = await page.pdf({
+      format: 'A4',
+      printBackground: true,
+      margin: { top: '1cm', bottom: '1cm', left: '1cm', right: '1cm' }
+    });
+
+    const doc = await PDFDocument.load(pdfBytes);
+    const copiedPages = await mergedPdf.copyPages(doc, doc.getPageIndices());
+    copiedPages.forEach((p) => mergedPdf.addPage(p));
+  }
+
+  const mergedPdfBytes = await mergedPdf.save();
+  fs.writeFileSync('WebGPU_Fundamentals_Full.pdf', mergedPdfBytes);
+  
+  console.log('Done! Created WebGPU_Fundamentals_Full.pdf');
+  await browser.close();
+}
+
+generateTutorialPdf().catch(console.error);
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "webgpufundamentals",
       "version": "0.0.1",
       "license": "MIT",
+      "dependencies": {
+        "pdf-lib": "^1.17.1"
+      },
       "devDependencies": {
         "@gfxfundamentals/lesson-builder": "github:gfxfundamentals/lesson-builder#v2.4.4",
         "@gfxfundamentals/live-editor": "github:gfxfundamentals/live-editor#v1.5.4",
@@ -34,7 +37,7 @@
         "ld-check-dependencies": "^1.2.2",
         "load-grunt-tasks": "^5.1.0",
         "minami": "^1.2.3",
-        "puppeteer": "^24.34.0",
+        "puppeteer": "^24.37.1",
         "semver": "^7.7.3",
         "servez": "^2.3.2",
         "ts-node": "^10.9.2",
@@ -209,6 +212,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -249,6 +253,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -426,7 +431,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1312386.tgz",
       "integrity": "sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@gfxfundamentals/lesson-builder/node_modules/puppeteer": {
       "version": "22.15.0",
@@ -619,10 +625,28 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@pdf-lib/standard-fonts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
+      "integrity": "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.6"
+      }
+    },
+    "node_modules/@pdf-lib/upng": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
+      "integrity": "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.10"
+      }
+    },
     "node_modules/@puppeteer/browsers": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.11.2.tgz",
-      "integrity": "sha512-GBY0+2lI9fDrjgb5dFL9+enKXqyOPok9PXg/69NVkjW3bikbK9RQrNrI3qccQXmDNN7ln4j/yL89Qgvj/tfqrw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.12.0.tgz",
+      "integrity": "sha512-Xuq42yxcQJ54ti8ZHNzF5snFvtpgXzNToJ1bXUGQRaiO8t+B6UM8sTUJfvV+AJnqtkJU/7hdy6nbKyA12aHtRw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -700,8 +724,7 @@
       "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
       "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/markdown-it": {
       "version": "14.1.2",
@@ -720,8 +743,7 @@
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
@@ -736,6 +758,7 @@
       "integrity": "sha512-DZ8VwRFUNzuqJ5khrvwMXHmvPe+zGayJhr2CDNiKB1WBE1ST8Djl00D0IC4vvNmHMdj6DlbYRIaFE7WHjlDl5w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -808,6 +831,7 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -1002,6 +1026,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1585,9 +1610,9 @@
       }
     },
     "node_modules/chromium-bidi": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-13.0.1.tgz",
-      "integrity": "sha512-c+RLxH0Vg2x2syS9wPw378oJgiJNXtYXUvnVAldUlt5uaHekn0CCU7gPksNgHjrH1qFhmjVXQj4esvuthuC7OQ==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-13.1.1.tgz",
+      "integrity": "sha512-zB9MpoPd7VJwjowQqiW3FKOvQwffFMjQ8Iejp5ZW+sJaKLRhZX1sTxzl3Zt22TDB4zP0OOqs8lRoY7eAW5geyQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1936,11 +1961,12 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1551306",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1551306.tgz",
-      "integrity": "sha512-CFx8QdSim8iIv+2ZcEOclBKTQY6BI1IEDa7Tm9YkwAXzEWFndTEzpTo5jAUhSnq24IC7xaDw0wvGcm96+Y3PEg==",
+      "version": "0.0.1566079",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1566079.tgz",
+      "integrity": "sha512-MJfAEA1UfVhSs7fbSQOG4czavUp1ajfg6prlAN0+cmfa2zNjaIbvq8VneP7do1WAQQIvgNJWSMeP6UyI90gIlQ==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/diff": {
       "version": "4.0.4",
@@ -2220,6 +2246,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3263,6 +3290,7 @@
       "integrity": "sha512-/ABUy3gYWu5iBmrUSRBP97JLpQUm0GgVveDCp6t3yRNIoltIYw7rEj3g5y1o2PGPR2vfTRGa7WC/LZHLTXnEzA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "dateformat": "~4.6.2",
         "eventemitter2": "~0.4.13",
@@ -5053,6 +5081,12 @@
         "node": ">= 14"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -5222,6 +5256,24 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pdf-lib": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
+      "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@pdf-lib/standard-fonts": "^1.0.0",
+        "@pdf-lib/upng": "^1.0.1",
+        "pako": "^1.0.11",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/pdf-lib/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/pend": {
       "version": "1.2.0",
@@ -5422,18 +5474,18 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "24.36.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.36.1.tgz",
-      "integrity": "sha512-uPiDUyf7gd7Il1KnqfNUtHqntL0w1LapEw5Zsuh8oCK8GsqdxySX1PzdIHKB2Dw273gWY4MW0zC5gy3Re9XlqQ==",
+      "version": "24.37.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.37.1.tgz",
+      "integrity": "sha512-iugAcwjRIX6XsMS1dzWbjKKUcEE0ZmmRbV0T6RyTtXNSHyBdss0r9GYJ9eOjUZfOoWeKCIOAptogdHYoBbJDeA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "2.11.2",
-        "chromium-bidi": "13.0.1",
+        "@puppeteer/browsers": "2.12.0",
+        "chromium-bidi": "13.1.1",
         "cosmiconfig": "^9.0.0",
-        "devtools-protocol": "0.0.1551306",
-        "puppeteer-core": "24.36.1",
+        "devtools-protocol": "0.0.1566079",
+        "puppeteer-core": "24.37.1",
         "typed-query-selector": "^2.12.0"
       },
       "bin": {
@@ -5444,16 +5496,16 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "24.36.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.36.1.tgz",
-      "integrity": "sha512-L7ykMWc3lQf3HS7ME3PSjp7wMIjJeW6+bKfH/RSTz5l6VUDGubnrC2BKj3UvM28Y5PMDFW0xniJOZHBZPpW1dQ==",
+      "version": "24.37.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.37.1.tgz",
+      "integrity": "sha512-ylRJReaA6kd/CrahdrxxnSZf5S2hf1QR0S39QeoS55fuBoOl4UggGPW94zheu9lmCokpRQpa7q8r98xYyiQl0Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "2.11.2",
-        "chromium-bidi": "13.0.1",
+        "@puppeteer/browsers": "2.12.0",
+        "chromium-bidi": "13.1.1",
         "debug": "^4.4.3",
-        "devtools-protocol": "0.0.1551306",
+        "devtools-protocol": "0.0.1566079",
         "typed-query-selector": "^2.12.0",
         "webdriver-bidi-protocol": "0.4.0",
         "ws": "^8.19.0"
@@ -6517,6 +6569,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "ld-check-dependencies": "^1.2.2",
     "load-grunt-tasks": "^5.1.0",
     "minami": "^1.2.3",
-    "puppeteer": "^24.34.0",
+    "puppeteer": "^24.37.1",
     "semver": "^7.7.3",
     "servez": "^2.3.2",
     "ts-node": "^10.9.2",
@@ -63,5 +63,8 @@
   "bugs": {
     "url": "https://github.com/gfxfundamentals/webgpufundamentals/issues"
   },
-  "homepage": "https://github.com/gfxfundamentals/webgpufundamentals"
+  "homepage": "https://github.com/gfxfundamentals/webgpufundamentals",
+  "dependencies": {
+    "pdf-lib": "^1.17.1"
+  }
 }


### PR DESCRIPTION
Apologies for the vibe coded solution, but I think it will help.
The change adds a script to scrape the website from localhost and dump to pdf.
Feel free to reject if you don't want it, or repurpose if you want changes on top

The generated pdf is 145MB - it can be compressed with

```bash
gs -sDEVICE=pdfwrite -dCompatibilityLevel=1.4 \
   -dPDFSETTINGS=/ebook -dNOPAUSE -dQUIET -dBATCH \
   -sOutputFile=output_compressed.pdf WebGPU_Fundamentals_Full.pdf
```