### PR TITLE
Add missing diffs to orthographic projection article

### DIFF
--- a/webgpu/lessons/webgpu-orthographic-projection.md
+++ b/webgpu/lessons/webgpu-orthographic-projection.md
@@ -979,6 +979,34 @@ Now that we have the data, we need to change our pipeline to use it.
   });
 ```
 
+We need to remove the old color data from our uniform.
+
+```js
+-  const uniformBufferSize = (4 + 16) * 4;
++  const uniformBufferSize = (16) * 4;
+  const uniformBuffer = device.createBuffer({
+    label: "uniforms",
+    size: uniformBufferSize,
+    usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+  });
+
+  const uniformValues = new Float32Array(uniformBufferSize / 4);
+
+  // offsets to the various uniform values in float32 indices
+-  const kColorOffset = 0;
+-  const kMatrixOffset = 4;
++  const kMatrixOffset = 0;
+
+-  const colorValue = uniformValues.subarray(kColorOffset, kColorOffset + 4);
+  const matrixValue = uniformValues.subarray(
+      kMatrixOffset,
+      kMatrixOffset + 16,
+  );
+
+-  // The color will not change so let's set it once at init time
+-  colorValue.set([Math.random(), Math.random(), Math.random(), 1]);
+```
+
 We no longer need to make an index buffer.
 
 ```js


### PR DESCRIPTION
The [orthographic projection article](https://webgpufundamentals.org/webgpu/lessons/webgpu-orthographic-projection.html) does not mention that the old, constant color data needs to be removed from the uniform when we switch to passing a color per face using inter-stage variables.

This can take a while to spot when following along using the diffs, as the shader still runs but produces a warped geometry.

Thanks for the great resource!